### PR TITLE
APIで取得した天気予報データを永続化させたい

### DIFF
--- a/WeatherReport.xcodeproj/xcuserdata/soraoya.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WeatherReport.xcodeproj/xcuserdata/soraoya.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>API.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WeatherReport.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/WeatherReport/Sources/Entity/ForecastEntity.swift
+++ b/WeatherReport/Sources/Entity/ForecastEntity.swift
@@ -1,0 +1,99 @@
+//
+//  ForecastEntity.swift
+//  WeatherReport
+//
+//  Created by Sora Oya on 2025/04/16.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class ForecastEntity {
+    @Attribute(.unique) var id: String
+    var cityName: String
+    var displayCityName: String
+    var lat: Double
+    var lon: Double
+    var expirationDate: Date
+    var weathers: [WeatherEntity]
+
+    init(city: Forecast.City, displayCityName: String, lat: Double, lon: Double, weathers: [WeatherEntity]) {
+        id = Self.generateIdentifier(city: city, lat: lat, lon: lon)
+        cityName = city.name ?? "現在地"
+        self.displayCityName = displayCityName
+        self.lat = lat
+        self.lon = lon
+        expirationDate = Date().nextMidnight
+        self.weathers = weathers
+    }
+
+    private static func generateIdentifier(city: Forecast.City, lat: Double, lon: Double) -> String {
+        switch city {
+        case .current:
+            return "current_\(lat.formatted(.number))_\(lon.formatted(.number))"
+        default:
+            return "\(city.name?.lowercased() ?? "")_\(lat.formatted(.number))_\(lon.formatted(.number))"
+        }
+    }
+}
+
+@Model
+final class WeatherEntity {
+    @Attribute(.unique) var timestamp: Date
+    var temperature: Double
+    var maxTemperature: Double
+    var minTemperature: Double
+    var humidity: Int
+    var weatherDescription: String
+    var iconCode: String
+    var windSpeed: Double
+    var windDeg: Int
+    var precipitation: Double
+    var pod: String
+
+    @Relationship(inverse: \ForecastEntity.weathers)
+    var forecast: ForecastEntity?
+
+    init(
+        date: String,
+        temperature: Double,
+        maxTemperature: Double,
+        minTemperature: Double,
+        humidity: Int,
+        description: String,
+        iconCode: String,
+        windSpeed: Double,
+        windDeg: Int,
+        pop: Double,
+        pod: String
+    ) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        timestamp = formatter.date(from: date) ?? Date()
+        self.temperature = temperature
+        self.maxTemperature = maxTemperature
+        self.minTemperature = minTemperature
+        self.humidity = humidity
+        weatherDescription = description
+        self.iconCode = iconCode
+        self.windSpeed = windSpeed
+        self.windDeg = windDeg
+        precipitation = pop
+        self.pod = pod
+    }
+}
+
+extension Date {
+    var nextMidnight: Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo") ?? .current
+        return calendar.nextDate(
+            after: self,
+            matching: DateComponents(hour: 0, minute: 0),
+            matchingPolicy: .nextTime,
+            repeatedTimePolicy: .first,
+            direction: .forward
+        ) ?? addingTimeInterval(86400)
+    }
+}

--- a/WeatherReport/Sources/Models/Foecast.swift
+++ b/WeatherReport/Sources/Models/Foecast.swift
@@ -24,7 +24,7 @@ struct Forecast: Hashable {
 
     var weather: [Weather]
     var city: City?
-    var cityName: String
+    var displayCityName: String
     var lat: Double
     var lon: Double
 

--- a/WeatherReport/Sources/UI/Views/WeatherReportApp.swift
+++ b/WeatherReport/Sources/UI/Views/WeatherReportApp.swift
@@ -5,6 +5,7 @@
 //  Created by Sora Oya on 2025/04/14.
 //
 
+import SwiftData
 import SwiftUI
 
 @main
@@ -19,6 +20,7 @@ struct WeatherReportApp: App {
             }
             .navigationViewStyle(.stack)
             .environmentObject(navigator)
+            .modelContainer(ForecastDataManager.shared.container)
         }
     }
 }

--- a/WeatherReport/Sources/Utils/ForecastDataManager.swift
+++ b/WeatherReport/Sources/Utils/ForecastDataManager.swift
@@ -1,0 +1,72 @@
+//
+//  ForecastDataManager.swift
+//  WeatherReport
+//
+//  Created by Sora Oya on 2025/04/16.
+//
+
+import Foundation
+import SwiftData
+
+final class ForecastDataManager {
+    static let shared = ForecastDataManager()
+
+    let container: ModelContainer
+    private let context: ModelContext
+
+    init() {
+        do {
+            container = try ModelContainer(
+                for: ForecastEntity.self,
+                WeatherEntity.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: false)
+            )
+            context = ModelContext(container)
+        } catch {
+            fatalError("SwiftDataコンテナの初期化に失敗しました: \(error)")
+        }
+    }
+
+    @MainActor
+    func saveForecast(_ forecast: Forecast, city: Forecast.City) async {
+        deleteExistingData(for: city.name ?? "現在地")
+
+        let forecastEntity = ForecastEntity(forecast: forecast, city: city)
+        context.insert(forecastEntity)
+
+        do {
+            try context.save()
+        } catch {}
+    }
+
+    @MainActor
+    private func deleteExistingData(for cityName: String) {
+        let predicate = #Predicate<ForecastEntity> { $0.cityName == cityName }
+        let descriptor = FetchDescriptor<ForecastEntity>(predicate: predicate)
+
+        do {
+            let results = try context.fetch(descriptor)
+            results.forEach { context.delete($0) }
+        } catch {}
+    }
+
+    @MainActor
+    func fetchCachedForecast(cityName: String) -> Forecast? {
+        let currentDate = Date()
+
+        let predicate = #Predicate<ForecastEntity> {
+            $0.cityName == cityName && $0.expirationDate > currentDate
+        }
+
+        let descriptor = FetchDescriptor(
+            predicate: predicate,
+            sortBy: [SortDescriptor(\.expirationDate, order: .reverse)]
+        )
+
+        guard let entity = try? context.fetch(descriptor).first else {
+            return nil
+        }
+
+        return .init(entity: entity)
+    }
+}

--- a/WeatherReport/Sources/ViewModels/WeatherForecastViewModel.swift
+++ b/WeatherReport/Sources/ViewModels/WeatherForecastViewModel.swift
@@ -31,6 +31,11 @@ final class WeatherForecastViewModel: ObservableObject {
         defer { isLoading = false }
 
         do {
+            if let cachedForecast = ForecastDataManager.shared.fetchCachedForecast(cityName: city.name ?? "") {
+                row = .init(forecast: cachedForecast)
+                isLoading = false
+                return
+            }
             let forecast = try await forecastService.fetchForecast(for: city)
             row = .init(forecast: forecast)
         } catch {
@@ -59,7 +64,7 @@ extension WeatherForecastViewModel {
 extension WeatherForecastViewModel.Row {
     init(forecast: Forecast) {
         self.init(
-            cityName: forecast.cityName,
+            cityName: forecast.displayCityName,
             weather: forecast.weather.map { .init(weather: $0) }
         )
     }


### PR DESCRIPTION
Close #8 

## 変更内容
- `SwiftData`を活用してAPIから取得した天気予報データをキャッシュし永続化するようにした。
- キャッシュの有効期限は、取得してから日付が変更されるまで。
- `SwiftData`に保存用の`ForecastEntity`モデルクラスを追加。
- データの保存、読み取り、削除を担う`ForecastDataManager`を追加。